### PR TITLE
[build] Use absolute path for Mono libs and don't hardcode specific version

### DIFF
--- a/AtkCocoa.xcodeproj/project.pbxproj
+++ b/AtkCocoa.xcodeproj/project.pbxproj
@@ -175,18 +175,18 @@
 		AE47D3E31F0E764B00678275 /* gailwindow.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; indentWidth = 2; path = gailwindow.c; sourceTree = "<group>"; };
 		AE47D3E41F0E764B00678275 /* NSAccessibilityElement+AtkCocoa.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; path = "NSAccessibilityElement+AtkCocoa.c"; sourceTree = "<group>"; };
 		AE47D4341F0E781500678275 /* atk-cocoa */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "atk-cocoa"; sourceTree = "<group>"; };
-		AE47D4361F0E789100678275 /* libatk-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libatk-1.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libatk-1.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D4371F0E789100678275 /* libcairo.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcairo.2.dylib; path = ../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libcairo.2.dylib; sourceTree = "<group>"; };
-		AE47D4381F0E789100678275 /* libgdk_pixbuf-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgdk_pixbuf-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libgdk_pixbuf-2.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D4391F0E789100678275 /* libgdk-quartz-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgdk-quartz-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libgdk-quartz-2.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D43A1F0E789100678275 /* libgio-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgio-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libgio-2.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D43B1F0E789100678275 /* libglib-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libglib-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libglib-2.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D43C1F0E789100678275 /* libgtk-quartz-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgtk-quartz-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libgtk-quartz-2.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D43D1F0E789100678275 /* libintl.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libintl.8.dylib; path = ../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libintl.8.dylib; sourceTree = "<group>"; };
-		AE47D43E1F0E789100678275 /* libpango-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libpango-1.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libpango-1.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D4481F0E78D200678275 /* libgobject-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgobject-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libgobject-2.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D4491F0E78D200678275 /* libpangocairo-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libpangocairo-1.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libpangocairo-1.0.0.dylib"; sourceTree = "<group>"; };
-		AE47D44C1F0E7E0800678275 /* libgmodule-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgmodule-2.0.0.dylib"; path = "../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0/lib/libgmodule-2.0.0.dylib"; sourceTree = "<group>"; };
+		AE47D4361F0E789100678275 /* libatk-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libatk-1.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libatk-1.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D4371F0E789100678275 /* libcairo.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcairo.2.dylib; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libcairo.2.dylib"; sourceTree = "<absolute>"; };
+		AE47D4381F0E789100678275 /* libgdk_pixbuf-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgdk_pixbuf-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdk_pixbuf-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D4391F0E789100678275 /* libgdk-quartz-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgdk-quartz-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdk-quartz-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D43A1F0E789100678275 /* libgio-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgio-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libgio-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D43B1F0E789100678275 /* libglib-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libglib-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libglib-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D43C1F0E789100678275 /* libgtk-quartz-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgtk-quartz-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libgtk-quartz-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D43D1F0E789100678275 /* libintl.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libintl.8.dylib; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libintl.8.dylib"; sourceTree = "<absolute>"; };
+		AE47D43E1F0E789100678275 /* libpango-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libpango-1.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libpango-1.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D4481F0E78D200678275 /* libgobject-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgobject-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D4491F0E78D200678275 /* libpangocairo-1.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libpangocairo-1.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libpangocairo-1.0.0.dylib"; sourceTree = "<absolute>"; };
+		AE47D44C1F0E7E0800678275 /* libgmodule-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libgmodule-2.0.0.dylib"; path = "/Library/Frameworks/Mono.framework/Versions/Current/lib/libgmodule-2.0.0.dylib"; sourceTree = "<absolute>"; };
 		AE47D44E1F0E874F00678275 /* acmarshal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = acmarshal.c; sourceTree = "<group>"; };
 		AE47D4501F0FA39100678275 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		AE47D4511F0FA39100678275 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -594,7 +594,7 @@
 				HEADER_SEARCH_PATHS = "atk-cocoa/";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks/Mono.framework/Versions/5.4.0/lib",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks/Mono.framework/Versions/Current/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = (
@@ -638,7 +638,7 @@
 				HEADER_SEARCH_PATHS = "atk-cocoa/";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(LOCAL_LIBRARY_DIR)/Frameworks/Mono.framework/Versions/5.4.0/lib",
+					"$(LOCAL_LIBRARY_DIR)/Frameworks/Mono.framework/Versions/Current/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = (


### PR DESCRIPTION
The Xcode project was hardcoding a relative path to Mono and a specific version, `../../../../../../Library/Frameworks/Mono.framework/Versions/5.4.0`.

This changes it to use the absolute path, `/Library/Frameworks/Mono.framework/Versions/Current`