### PR TITLE
VSTS 648646: Voice Over knows the content of password entries

### DIFF
--- a/AtkCocoa/ACAccessibilityTextFieldElement.c
+++ b/AtkCocoa/ACAccessibilityTextFieldElement.c
@@ -105,7 +105,17 @@ get_entry_text (AcElement *element)
 
 - (NSString *)accessibilityValueDescription
 {
-    return @"contains secure text";
+    GObject *widget = ac_element_get_owner ([self delegate]);
+    
+    if (!GTK_IS_ENTRY (widget)) {
+        return nil;
+    }
+    
+    if (!gtk_entry_get_visibility (GTK_ENTRY (widget))){
+        return @"contains secure text";
+    }
+    
+    return [super accessibilityValueDescription];
 }
 
 - (NSRange)accessibilityRangeForLine:(NSInteger)line

--- a/AtkCocoa/ACAccessibilityTextFieldElement.c
+++ b/AtkCocoa/ACAccessibilityTextFieldElement.c
@@ -38,6 +38,10 @@
         return nil;
 	}
 
+    if (!gtk_entry_get_visibility (GTK_ENTRY (owner))){
+        return nil;
+    }
+
     return nsstring_from_cstring (get_entry_text([self delegate]));
 }
 

--- a/AtkCocoa/ACAccessibilityTextFieldElement.c
+++ b/AtkCocoa/ACAccessibilityTextFieldElement.c
@@ -38,10 +38,6 @@
         return nil;
 	}
 
-    if (!gtk_entry_get_visibility (GTK_ENTRY (owner))){
-        return nil;
-    }
-
     return nsstring_from_cstring (get_entry_text([self delegate]));
 }
 
@@ -89,11 +85,27 @@ const char *
 get_entry_text (AcElement *element)
 {
     GtkWidget *widget = gtk_accessible_get_widget(GTK_ACCESSIBLE (element));
-    if (GTK_IS_ENTRY(widget)) {
-        return gtk_entry_get_text(GTK_ENTRY (widget));
+    
+    if (!GTK_IS_ENTRY(widget)) {
+        NSLog(@"This is not a GTK entry");
+        return "";
     }
+    
+    NSString *value = nsstring_from_cstring (gtk_entry_get_text(GTK_ENTRY (widget)));
+    
+    if (!gtk_entry_get_visibility (GTK_ENTRY (widget))){
+        value = [@"" stringByPaddingToLength:value.length withString: @"•" startingAtIndex:0];
+    }
+    
+    if (value == nil)
+        return "";
+    
+    return [value cStringUsingEncoding:NSUTF8StringEncoding];
+}
 
-    return "";
+- (NSString *)accessibilityValueDescription
+{
+    return @"contains secure text";
 }
 
 - (NSRange)accessibilityRangeForLine:(NSInteger)line

--- a/AtkCocoa/gailentry.c
+++ b/AtkCocoa/gailentry.c
@@ -1076,10 +1076,10 @@ _gail_entry_insert_text_cb (GtkEntry *entry,
 
   if (arg1 != NULL && *arg1 != 0) {
     NSAccessibilityPostNotificationWithUserInfo(ac_element_get_accessibility_element(AC_ELEMENT(accessible)),
-                                                NSAccessibilityAnnouncementRequestedNotification,
-                                                @{ NSAccessibilityAnnouncementKey : nsstring_from_cstring(arg1),
-                                                   NSAccessibilityPriorityKey: @(NSAccessibilityPriorityHigh)
-                                                   });
+                                                  NSAccessibilityAnnouncementRequestedNotification,
+                                              @{ NSAccessibilityAnnouncementKey : gtk_entry_get_visibility (entry) ? nsstring_from_cstring(arg1) : @"•",
+                                                     NSAccessibilityPriorityKey: @(NSAccessibilityPriorityHigh)
+                                                     });
   }
 
   /*


### PR DESCRIPTION
Demo:

![password-fix](https://user-images.githubusercontent.com/1524073/44553930-29061000-a6fd-11e8-8b8d-4a2c65f9d43a.gif)

As you can see from the gif, chars in the password entry are not announced while typing. Neither the content of the password field is visible to Voice Over on Tab.