### PR TITLE
Autoscroll viewport when accessibility focus changes

### DIFF
--- a/AtkCocoa/ACAccessibilityElement.c
+++ b/AtkCocoa/ACAccessibilityElement.c
@@ -1018,13 +1018,7 @@ widget_visible_in_viewport (GtkWidget *widget)
         rect.width = viewport->allocation.width;
         rect.height = viewport->allocation.height;
 
-        if (((widget->allocation.x + widget->allocation.width) < rect.x) ||
-            ((widget->allocation.y + widget->allocation.height) < rect.y) ||
-            (widget->allocation.x > (rect.x + rect.width)) ||
-            (widget->allocation.y > (rect.y + rect.height)))
-            ret = FALSE;
-        else
-            ret = TRUE;
+        ret = gdk_rectangle_intersect (&widget->allocation, &rect, NULL);
     }
     else
     {

--- a/AtkCocoa/ACAccessibilityElement.c
+++ b/AtkCocoa/ACAccessibilityElement.c
@@ -1039,20 +1039,14 @@ widget_visible_in_viewport (GtkWidget *widget)
 }
 
 static gboolean
-focus_viewport_child (GtkWidget *widget)
+focus_viewport_child (GtkWidget *widget, GtkWidget *focus)
 {
-    GtkWidget *toplevel;
-    GtkWidget *focus;
     GtkAdjustment *adj;
     GtkAllocation widget_alloc;
     GtkAllocation focus_alloc;
     int x, y;
     gdouble value;
 
-    toplevel = gtk_widget_get_toplevel(widget);
-    g_return_val_if_fail(GTK_IS_WIDGET(toplevel), FALSE);
-
-    focus = gtk_window_get_focus(GTK_WINDOW(toplevel));
     if (focus == NULL)
         return FALSE;
 
@@ -1101,7 +1095,7 @@ focus_viewport_child (GtkWidget *widget)
 
         if (viewport != NULL && !widget_visible_in_viewport(widget))
         {
-            focus_viewport_child (viewport);
+            focus_viewport_child (viewport, widget);
         }
 
         gtk_widget_grab_focus(widget);


### PR DESCRIPTION
Fixes VSTS #752820

This is a followup from https://github.com/mono/bockbuild/pull/126

In that patch, GTK moves the viewport when child widget focus changes. But accessibility focus may sometimes be different from keyboard focus, so we need to implement this in AtkCocoa to handle cases when the user uses Ctrl-Option-ArrowKey and moves accessibility focus into a widget that doesn't accept keyboard focus (such as a label).