### PR TITLE
[Notebook] Remove excess notebook children

### DIFF
--- a/AtkCocoa/ACAccessibilityNotebookElement.c
+++ b/AtkCocoa/ACAccessibilityNotebookElement.c
@@ -46,8 +46,16 @@
 - (NSArray *)accessibilityChildrenInNavigationOrder
 {
     //NSArray *c = [super accessibilityChildrenInNavigationOrder];
+    GtkWidget *notebook = ac_element_get_owner ([self delegate]);
+    gint n_pages = gtk_notebook_get_n_pages (GTK_NOTEBOOK (notebook));
 
-    return [super accessibilityChildren];
+    NSMutableArray *ret = [[super accessibilityChildren] mutableCopy];
+
+    if (n_pages > 0)
+        for (int n = 0; n < n_pages; n++)
+            [ret removeLastObject];
+
+    return ret;
 }
 
 - (id)accessibilityValue


### PR DESCRIPTION
For some reason notebook tab children are being added twice. For example
if there are 4 tabs for a notebook then accessibilityChildrenInNavigationOrder
is showing that there are 9 children (4 tabs, 1 content area, 4 "ghost" tab
children).

Fixes VSTS #1002798